### PR TITLE
Initialize Next.js frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
-# boxmind
+# BoxMind Frontend
+
+This repository contains a minimal Next.js + TypeScript + Tailwind CSS frontend implementing a neumorphism design. Components use Framer Motion and GSAP for small animations and React Hook Form with Zod for validation.
+
+## Development
+
+Node modules are not included in this environment. After cloning, install dependencies and run the dev server:
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+The app uses the Next.js App Router with basic pages for Home, Box Detail, and Reminders.

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    appDir: true
+  }
+};
+
+module.exports = nextConfig;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "boxmind-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.2.0",
+    "react": "18.3.1",
+    "react-dom": "18.3.1",
+    "react-hook-form": "7.45.0",
+    "zod": "3.22.4",
+    "framer-motion": "11.0.17",
+    "gsap": "3.12.5"
+  },
+  "devDependencies": {
+    "autoprefixer": "10.4.17",
+    "postcss": "8.4.35",
+    "tailwindcss": "3.4.1",
+    "typescript": "5.4.2",
+    "eslint": "8.57.0",
+    "eslint-config-next": "14.2.0"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/src/app/box/[id]/page.tsx
+++ b/frontend/src/app/box/[id]/page.tsx
@@ -1,0 +1,21 @@
+'use client';
+import { useParams } from 'next/navigation';
+import { Button } from '@/components/ui/Button';
+import ItemGrid from '@/components/ItemGrid';
+import AddItem from '@/components/AddItem';
+
+export default function BoxDetail() {
+  const params = useParams();
+  const boxName = decodeURIComponent(String(params.id || ''));
+
+  return (
+    <main className="p-4 space-y-6">
+      <header className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">{boxName}</h1>
+        <AddItem />
+      </header>
+      <p className="text-sm text-gray-600">마우스로 물건 위치를 조정할 수 있어요</p>
+      <ItemGrid />
+    </main>
+  );
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,0 +1,18 @@
+import './globals.css';
+import type { ReactNode } from 'react';
+import { SUIT_Variable } from 'next/font/google';
+
+const suit = SUIT_Variable({ subsets: ['latin'], weight: ['400', '700'] });
+
+export const metadata = {
+  title: 'BoxMind',
+  description: '공간 기반 정리 보조 SaaS',
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="ko" className={suit.className}>
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,0 +1,16 @@
+import BoxList from '@/components/BoxList';
+import Insights from '@/components/Insights';
+import { Button } from '@/components/ui/Button';
+
+export default function Home() {
+  return (
+    <main className="p-4 space-y-8">
+      <header className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">내 정리 공간</h1>
+        <Button onClick={() => console.log('Create box')}>새 공간 만들기</Button>
+      </header>
+      <BoxList />
+      <Insights />
+    </main>
+  );
+}

--- a/frontend/src/app/reminders/page.tsx
+++ b/frontend/src/app/reminders/page.tsx
@@ -1,0 +1,16 @@
+import { Card } from '@/components/ui/Card';
+
+export default function ReminderPage() {
+  const reminders = [
+    { type: 'expiry', message: '우유 유통기한 임박', color: 'bg-[#FFC107]' },
+    { type: 'reorg', message: '청소기 30일 미사용', color: 'bg-[#FF5252]' },
+  ];
+
+  return (
+    <main className="p-4 space-y-4" aria-label="알림 목록">
+      {reminders.map((r, i) => (
+        <Card key={i} className={`p-4 ${r.color}`}>{r.message}</Card>
+      ))}
+    </main>
+  );
+}

--- a/frontend/src/components/AddItem.tsx
+++ b/frontend/src/components/AddItem.tsx
@@ -1,0 +1,39 @@
+'use client';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { Button } from './ui/Button';
+import InputField from './ui/InputField';
+import Modal from './ui/Modal';
+import { useState } from 'react';
+
+const schema = z.object({
+  name: z.string().min(1),
+  category: z.string().min(1),
+});
+
+type FormData = z.infer<typeof schema>;
+
+export default function AddItem() {
+  const [open, setOpen] = useState(false);
+  const { register, handleSubmit, formState: { errors } } = useForm<FormData>({ resolver: zodResolver(schema) });
+
+  const onSubmit = (data: FormData) => {
+    console.log('물건 등록', data);
+    setOpen(false);
+  };
+
+  return (
+    <>
+      <Button onClick={() => setOpen(true)}>물건 추가하기</Button>
+      <Modal open={open} onClose={() => setOpen(false)} title="물건 등록">
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+          <InputField label="물건명" name="name" register={register} required />
+          <InputField label="카테고리" name="category" register={register} required />
+          {errors.name && <span className="text-red-500 text-sm">필수 입력</span>}
+          <Button type="submit" className="w-full">등록</Button>
+        </form>
+      </Modal>
+    </>
+  );
+}

--- a/frontend/src/components/BoxList.tsx
+++ b/frontend/src/components/BoxList.tsx
@@ -1,0 +1,23 @@
+'use client';
+import { motion } from 'framer-motion';
+import { Card } from './ui/Card';
+
+const boxes = [
+  { name: '냉장고', itemsCount: 12 },
+  { name: '화장대', itemsCount: 7 }
+];
+
+export default function BoxList() {
+  return (
+    <section aria-label="정리 공간 목록" className="grid md:grid-cols-2 gap-6">
+      {boxes.map((box) => (
+        <motion.div key={box.name} whileHover={{ scale: 1.02 }}>
+          <Card className="p-4 flex justify-between">
+            <span>{box.name}</span>
+            <span aria-label="items-count">{box.itemsCount}개</span>
+          </Card>
+        </motion.div>
+      ))}
+    </section>
+  );
+}

--- a/frontend/src/components/Insights.tsx
+++ b/frontend/src/components/Insights.tsx
@@ -1,0 +1,22 @@
+'use client';
+import { Card } from './ui/Card';
+
+export default function Insights() {
+  return (
+    <section className="space-y-4" aria-labelledby="insights-title">
+      <h2 id="insights-title" className="text-xl font-semibold">오래된 보관품 Top5</h2>
+      <Card className="p-4">차트 자리</Card>
+      <h3 className="text-lg font-medium">1년 넘게 안쓴 물건들</h3>
+      <Card className="p-4 flex justify-between">
+        <span>물건명</span>
+        <button
+          role="button"
+          className="underline"
+          onClick={() => console.log('정리 제안 클릭')}
+        >
+          정리 제안
+        </button>
+      </Card>
+    </section>
+  );
+}

--- a/frontend/src/components/ItemGrid.tsx
+++ b/frontend/src/components/ItemGrid.tsx
@@ -1,0 +1,19 @@
+'use client';
+import { motion } from 'framer-motion';
+import { Card } from './ui/Card';
+
+const items = Array.from({ length: 8 }, (_, i) => ({ id: i, name: `물건 ${i+1}` }));
+
+export default function ItemGrid() {
+  return (
+    <section className="grid grid-cols-2 md:grid-cols-4 gap-4" aria-label="물건 목록">
+      {items.map(item => (
+        <motion.div key={item.id} whileHover={{ y: -4 }}>
+          <Card className="h-44 flex items-center justify-center">
+            {item.name}
+          </Card>
+        </motion.div>
+      ))}
+    </section>
+  );
+}

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -1,0 +1,24 @@
+'use client';
+import { motion } from 'framer-motion';
+import { HTMLAttributes } from 'react';
+
+export interface ButtonProps extends HTMLAttributes<HTMLButtonElement> {
+  children: React.ReactNode;
+}
+
+export function Button({ children, onClick, ...props }: ButtonProps) {
+  return (
+    <motion.button
+      role="button"
+      whileTap={{ scale: 0.95 }}
+      className="rounded-2xl px-6 py-3 bg-background shadow-neu text-text"
+      onClick={(e) => {
+        console.log('Button clicked');
+        onClick?.(e as any);
+      }}
+      {...props}
+    >
+      {children}
+    </motion.button>
+  );
+}

--- a/frontend/src/components/ui/Card.tsx
+++ b/frontend/src/components/ui/Card.tsx
@@ -1,0 +1,10 @@
+import { HTMLAttributes } from 'react';
+
+export function Card({ className = '', ...props }: HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={`rounded-[20px] p-4 bg-background shadow-neu ${className}`}
+      {...props}
+    />
+  );
+}

--- a/frontend/src/components/ui/InputField.tsx
+++ b/frontend/src/components/ui/InputField.tsx
@@ -1,0 +1,24 @@
+'use client';
+import { HTMLInputTypeAttribute } from 'react';
+
+interface Props {
+  label: string;
+  type?: HTMLInputTypeAttribute;
+  register: any;
+  name: string;
+  required?: boolean;
+}
+
+export default function InputField({ label, type = 'text', register, name, required }: Props) {
+  return (
+    <label className="block space-y-1">
+      <span className="text-sm font-medium">{label}</span>
+      <input
+        {...register(name, { required })}
+        type={type}
+        aria-required={required}
+        className="w-full p-3 rounded-[14px] shadow-neu-inset placeholder-gray-400 focus:border focus:border-gray-400"
+      />
+    </label>
+  );
+}

--- a/frontend/src/components/ui/Modal.tsx
+++ b/frontend/src/components/ui/Modal.tsx
@@ -1,0 +1,34 @@
+'use client';
+import { gsap } from 'gsap';
+import { useEffect, useRef } from 'react';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  title: string;
+  children: React.ReactNode;
+}
+
+export default function Modal({ open, onClose, title, children }: Props) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (open && ref.current) {
+      gsap.fromTo(ref.current, { scale: 0.8, opacity: 0 }, { scale: 1, opacity: 1, duration: 0.4, ease: 'power2.out' });
+    }
+  }, [open]);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40" role="dialog" aria-modal="true" aria-labelledby="modalTitle">
+      <div ref={ref} className="bg-background p-6 rounded-[20px] shadow-neu max-w-md w-full">
+        <div className="flex justify-between items-center mb-4">
+          <h2 id="modalTitle" className="text-lg font-semibold">{title}</h2>
+          <button aria-label="Close" onClick={onClose}>X</button>
+        </div>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -1,0 +1,11 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply bg-background text-text font-sans;
+}
+
+button:focus {
+  outline: 2px solid #FF9800;
+}

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,22 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './src/**/*.{js,ts,jsx,tsx}'
+  ],
+  theme: {
+    extend: {
+      colors: {
+        background: '#E0E5EC',
+        text: '#303030'
+      },
+      fontFamily: {
+        sans: ['\'SUIT Variable\', \"Noto Sans KR\", sans-serif']
+      },
+      boxShadow: {
+        neu: "4px 4px 8px #A3B1C6, -4px -4px 8px #FFFFFF",
+        "neu-inset": "inset 4px 4px 8px #A3B1C6, inset -4px -4px 8px #FFFFFF"
+      }
+    },
+  },
+  plugins: [],
+};

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold a minimal Next.js+TS app in `frontend`
- add neumorphic Tailwind config and global styles
- implement basic pages with Box list, item grid and reminders
- add UI components with Framer Motion, GSAP and form validation
- update README with setup instructions

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e8b17dde4832ca82b34b9e62794e3