### PR TITLE
Frontend cleanup and API prep

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
     "react-dom": "18.3.1",
     "react-hook-form": "7.45.0",
     "zod": "3.22.4",
-    "framer-motion": "11.0.17",
-    "gsap": "3.12.5"
+    "framer-motion": "11.0.17"
   },
   "devDependencies": {
     "autoprefixer": "10.4.17",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,14 @@
-import BoxList from '@/components/BoxList';
-import Insights from '@/components/Insights';
-import AddBox from '@/components/AddBox';
-import Head from 'next/head';
+import { useEffect } from "react";
+import BoxList from "@/components/BoxList";
+import Insights from "@/components/Insights";
+import AddBox from "@/components/AddBox";
+import Head from "next/head";
 
 export default function Home() {
+  useEffect(() => {
+    console.log("[Home] page loaded");
+  }, []);
+
   return (
     <>
       <Head>

--- a/src/app/reminders/page.tsx
+++ b/src/app/reminders/page.tsx
@@ -1,12 +1,21 @@
-import { Card } from '@/components/ui/Card';
-import Head from 'next/head';
+import { useEffect, useState } from "react";
+import { Card } from "@/components/ui/Card";
+import Head from "next/head";
+import { fetchReminders } from "@/lib/api";
+
+interface Reminder {
+  type: "expiry" | "reorg";
+  message: string;
+  color: string;
+}
 
 export default function ReminderPage() {
-  const reminders = [
-    { type: 'expiry', message: '우유 유통기한 임박', color: 'bg-[#FFC107]' },
-    { type: 'reorg', message: '청소기 30일 미사용', color: 'bg-[#FF5252]' },
-  ];
-  console.log('[Reminders] viewed');
+  const [reminders, setReminders] = useState<Reminder[]>([]);
+
+  useEffect(() => {
+    console.log("[Reminders] page mounted");
+    fetchReminders("user").then(setReminders);
+  }, []);
 
   return (
     <>
@@ -15,7 +24,9 @@ export default function ReminderPage() {
       </Head>
       <main className="p-4 space-y-4" aria-label="알림 목록">
         {reminders.map((r, i) => (
-          <Card key={i} className={`p-4 ${r.color}`}>{r.message}</Card>
+          <Card key={i} className={`p-4 ${r.color}`}>
+            {r.message}
+          </Card>
         ))}
       </main>
     </>

--- a/src/components/AddBox.tsx
+++ b/src/components/AddBox.tsx
@@ -1,35 +1,65 @@
-'use client';
-import { useState } from 'react';
-import { useForm } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
-import { z } from 'zod';
-import { Button } from './ui/Button';
-import InputField from './ui/InputField';
-import Modal from './ui/Modal';
+"use client";
+// Form to add a new storage box
+import { useState, useCallback, memo } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { Button } from "./ui/Button";
+import InputField from "./ui/InputField";
+import Modal from "./ui/Modal";
+import { createBox } from "@/lib/api";
 
 const schema = z.object({ name: z.string().min(1) });
-
 type FormData = z.infer<typeof schema>;
 
-export default function AddBox() {
+function AddBox() {
   const [open, setOpen] = useState(false);
-  const { register, handleSubmit, formState: { errors } } = useForm<FormData>({ resolver: zodResolver(schema) });
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<FormData>({ resolver: zodResolver(schema) });
 
-  const onSubmit = (data: FormData) => {
-    console.log('[AddBox] Box created', { name: data.name });
+  const openModal = useCallback(() => {
+    console.log("[AddBox] open modal");
+    setOpen(true);
+  }, []);
+
+  const closeModal = useCallback(() => {
+    console.log("[AddBox] close modal");
     setOpen(false);
-  };
+  }, []);
+
+  const onSubmit = useCallback(
+    async (data: FormData) => {
+      console.log("[AddBox] submit", { name: data.name });
+      await createBox("user", data.name);
+      closeModal();
+    },
+    [closeModal],
+  );
 
   return (
     <>
-      <Button onClick={() => setOpen(true)}>새 공간 만들기</Button>
-      <Modal open={open} onClose={() => setOpen(false)} title="새 공간">
+      <Button onClick={openModal}>새 공간 만들기</Button>
+      <Modal open={open} onClose={closeModal} title="새 공간">
         <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
-          <InputField label="공간 이름" name="name" register={register} required />
-          {errors.name && <span className="text-red-500 text-sm">필수 입력</span>}
-          <Button type="submit" className="w-full">생성</Button>
+          <InputField
+            label="공간 이름"
+            name="name"
+            register={register}
+            required
+          />
+          {errors.name && (
+            <span className="text-red-500 text-sm">필수 입력</span>
+          )}
+          <Button type="submit" className="w-full">
+            생성
+          </Button>
         </form>
       </Modal>
     </>
   );
 }
+
+export default memo(AddBox);

--- a/src/components/AddItem.tsx
+++ b/src/components/AddItem.tsx
@@ -1,11 +1,13 @@
-'use client';
-import { useForm } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
-import { z } from 'zod';
-import { Button } from './ui/Button';
-import InputField from './ui/InputField';
-import Modal from './ui/Modal';
-import { useState } from 'react';
+"use client";
+// Form to add a new item to a box
+import { useState, useCallback, memo } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { Button } from "./ui/Button";
+import InputField from "./ui/InputField";
+import Modal from "./ui/Modal";
+import { createItem } from "@/lib/api";
 
 const schema = z.object({
   name: z.string().min(1),
@@ -16,39 +18,64 @@ const schema = z.object({
 
 type FormData = z.infer<typeof schema>;
 
-export default function AddItem() {
+function AddItem() {
   const [open, setOpen] = useState(false);
   const {
     register,
     handleSubmit,
-    formState: { errors }
+    formState: { errors },
   } = useForm<FormData>({ resolver: zodResolver(schema) });
 
-  const onSubmit = (data: FormData) => {
-    console.log('[AddItem] Item added', {
-      name: data.name,
-      category: data.category,
-      barcode: data.barcode || null
-    });
+  const openModal = useCallback(() => {
+    console.log("[AddItem] open modal");
+    setOpen(true);
+  }, []);
+
+  const closeModal = useCallback(() => {
+    console.log("[AddItem] close modal");
     setOpen(false);
-  };
+  }, []);
+
+  const onSubmit = useCallback(
+    async (data: FormData) => {
+      console.log("[AddItem] submit", data);
+      await createItem("box", {
+        name: data.name,
+        category: data.category,
+        barcode: data.barcode || undefined,
+      });
+      closeModal();
+    },
+    [closeModal],
+  );
 
   return (
     <>
-      <Button onClick={() => setOpen(true)}>물건 추가하기</Button>
-      <Modal open={open} onClose={() => setOpen(false)} title="물건 등록">
+      <Button onClick={openModal}>물건 추가하기</Button>
+      <Modal open={open} onClose={closeModal} title="물건 등록">
         <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
           <InputField label="물건명" name="name" register={register} required />
-          <InputField label="카테고리" name="category" register={register} required />
+          <InputField
+            label="카테고리"
+            name="category"
+            register={register}
+            required
+          />
           <InputField label="바코드" name="barcode" register={register} />
           <label className="block space-y-1">
             <span className="text-sm font-medium">사진</span>
-            <input type="file" {...register('photo')} className="w-full" />
+            <input type="file" {...register("photo")} className="w-full" />
           </label>
-          {errors.name && <span className="text-red-500 text-sm">필수 입력</span>}
-          <Button type="submit" className="w-full">등록</Button>
+          {errors.name && (
+            <span className="text-red-500 text-sm">필수 입력</span>
+          )}
+          <Button type="submit" className="w-full">
+            등록
+          </Button>
         </form>
       </Modal>
     </>
   );
 }
+
+export default memo(AddItem);

--- a/src/components/BoxList.tsx
+++ b/src/components/BoxList.tsx
@@ -1,23 +1,43 @@
-'use client';
-import { motion } from 'framer-motion';
-import { Card } from './ui/Card';
-import { cardHover } from '@/lib/animations';
+"use client";
+// Displays boxes for the current user
+import { useEffect, useState, memo } from "react";
+import { useRouter } from "next/navigation";
+import { motion } from "framer-motion";
+import { Card } from "./ui/Card";
+import { cardHover } from "@/lib/animations";
+import { fetchBoxes } from "@/lib/api";
 
-const boxes = [
-  { name: '냉장고', itemsCount: 12 },
-  { name: '화장대', itemsCount: 7 }
-];
+interface Box {
+  boxId: string;
+  name: string;
+  itemsCount?: number;
+}
 
-export default function BoxList() {
+function BoxList() {
+  const [boxes, setBoxes] = useState<Box[]>([]);
+  const router = useRouter();
+
+  useEffect(() => {
+    fetchBoxes("user").then(setBoxes);
+  }, []);
+
+  const selectBox = (box: Box) => {
+    console.log("[BoxList] select box", { box });
+    router.push(`/box/${encodeURIComponent(box.name)}`);
+  };
+
   return (
     <section aria-label="정리 공간 목록">
       <ul className="grid md:grid-cols-2 gap-6">
         {boxes.map((box) => (
-          <li key={box.name}>
-            <motion.div {...cardHover} style={{ willChange: 'transform' }}>
-              <Card className="p-4 flex justify-between">
+          <li key={box.boxId}>
+            <motion.div {...cardHover} style={{ willChange: "transform" }}>
+              <Card
+                className="p-4 flex justify-between cursor-pointer"
+                onClick={() => selectBox(box)}
+              >
                 <span>{box.name}</span>
-                <span aria-label="items-count">{box.itemsCount}개</span>
+                <span aria-label="items-count">{box.itemsCount ?? 0}개</span>
               </Card>
             </motion.div>
           </li>
@@ -26,3 +46,5 @@ export default function BoxList() {
     </section>
   );
 }
+
+export default memo(BoxList);

--- a/src/components/Insights.tsx
+++ b/src/components/Insights.tsx
@@ -1,15 +1,18 @@
-'use client';
-import { Card } from './ui/Card';
-import { useEffect } from 'react';
+"use client";
+// Displays simple insights placeholder
+import { useEffect, memo } from "react";
+import { Card } from "./ui/Card";
 
-export default function Insights() {
+function Insights() {
   useEffect(() => {
-    console.log('[Insights] Top 5 displayed');
-    console.log('[Insights] Cleanup suggested');
+    console.log("[Insights] mounted");
   }, []);
+
   return (
     <section className="space-y-4" aria-labelledby="insights-title">
-      <h2 id="insights-title" className="text-xl font-semibold">오래된 보관품 Top5</h2>
+      <h2 id="insights-title" className="text-xl font-semibold">
+        오래된 보관품 Top5
+      </h2>
       <Card className="p-4">차트 자리</Card>
       <h3 className="text-lg font-medium">1년 넘게 안쓴 물건들</h3>
       <Card className="p-4 flex justify-between">
@@ -17,7 +20,7 @@ export default function Insights() {
         <button
           role="button"
           className="underline"
-          onClick={() => console.log('정리 제안 클릭')}
+          onClick={() => console.log("[Insights] cleanup suggested")}
         >
           정리 제안
         </button>
@@ -25,3 +28,5 @@ export default function Insights() {
     </section>
   );
 }
+
+export default memo(Insights);

--- a/src/components/ItemGrid.tsx
+++ b/src/components/ItemGrid.tsx
@@ -1,17 +1,29 @@
-'use client';
-import { motion } from 'framer-motion';
-import { Card } from './ui/Card';
-import { cardHover } from '@/lib/animations';
+"use client";
+// Grid of items inside a box
+import { useEffect, useState, memo } from "react";
+import { motion } from "framer-motion";
+import { Card } from "./ui/Card";
+import { cardHover } from "@/lib/animations";
+import { fetchItems } from "@/lib/api";
 
-const items = Array.from({ length: 8 }, (_, i) => ({ id: i, name: `물건 ${i+1}` }));
+interface Item {
+  id: string;
+  name: string;
+}
 
-export default function ItemGrid() {
+function ItemGrid() {
+  const [items, setItems] = useState<Item[]>([]);
+
+  useEffect(() => {
+    fetchItems("box").then(setItems);
+  }, []);
+
   return (
     <section aria-label="물건 목록">
       <ul className="grid grid-cols-2 md:grid-cols-4 gap-4">
         {items.map((item) => (
           <li key={item.id}>
-            <motion.div {...cardHover} style={{ willChange: 'transform' }}>
+            <motion.div {...cardHover} style={{ willChange: "transform" }}>
               <Card className="h-44 flex items-center justify-center">
                 {item.name}
               </Card>
@@ -22,3 +34,5 @@ export default function ItemGrid() {
     </section>
   );
 }
+
+export default memo(ItemGrid);

--- a/src/components/icons/SvgIcon.tsx
+++ b/src/components/icons/SvgIcon.tsx
@@ -1,7 +1,8 @@
-import { HTMLAttributes } from 'react';
+// Reusable SVG icon component
+import { HTMLAttributes, memo } from "react";
 
 interface Props extends HTMLAttributes<SVGElement> {
-  name: 'fridge' | 'close';
+  name: "fridge" | "close";
 }
 
 const icons = {
@@ -10,18 +11,15 @@ const icons = {
   ),
   close: (
     <path strokeLinecap="round" strokeLinejoin="round" d="M6 6l6 6m0-6L6 12" />
-  )
+  ),
 };
 
-export default function SvgIcon({ name, ...props }: Props) {
+function SvgIcon({ name, ...props }: Props) {
   return (
-    <svg
-      viewBox="0 0 16 16"
-      fill="none"
-      stroke="currentColor"
-      {...props}
-    >
+    <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" {...props}>
       {icons[name]}
     </svg>
   );
 }
+
+export default memo(SvgIcon);

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,21 +1,22 @@
-'use client';
-import { motion } from 'framer-motion';
-import { HTMLAttributes } from 'react';
-import { buttonPress } from '@/lib/animations';
+"use client";
+// Basic button with small press animation
+import { motion } from "framer-motion";
+import { HTMLAttributes, memo } from "react";
+import { buttonPress } from "@/lib/animations";
 
 export interface ButtonProps extends HTMLAttributes<HTMLButtonElement> {
   children: React.ReactNode;
 }
 
-export function Button({ children, onClick, ...props }: ButtonProps) {
+function Button({ children, onClick, ...props }: ButtonProps) {
   return (
     <motion.button
       role="button"
       {...buttonPress}
       className="rounded-2xl px-6 py-3 bg-background shadow-neu text-text"
-      style={{ willChange: 'transform' }}
+      style={{ willChange: "transform" }}
       onClick={(e) => {
-        console.log('Button clicked');
+        console.log("[Button] click");
         onClick?.(e as any);
       }}
       {...props}
@@ -24,3 +25,6 @@ export function Button({ children, onClick, ...props }: ButtonProps) {
     </motion.button>
   );
 }
+
+export { Button };
+export default memo(Button);

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -1,6 +1,7 @@
-import { HTMLAttributes } from 'react';
+// Simple container with neumorphic shadow
+import { HTMLAttributes, memo } from "react";
 
-export function Card({ className = '', ...props }: HTMLAttributes<HTMLDivElement>) {
+function Card({ className = "", ...props }: HTMLAttributes<HTMLDivElement>) {
   return (
     <div
       className={`rounded-[20px] p-4 bg-background shadow-neu ${className}`}
@@ -8,3 +9,6 @@ export function Card({ className = '', ...props }: HTMLAttributes<HTMLDivElement
     />
   );
 }
+
+export { Card };
+export default memo(Card);

--- a/src/components/ui/InputField.tsx
+++ b/src/components/ui/InputField.tsx
@@ -1,5 +1,6 @@
-'use client';
-import { HTMLInputTypeAttribute } from 'react';
+"use client";
+// Input field wrapper used in forms
+import { HTMLInputTypeAttribute, memo } from "react";
 
 interface Props {
   label: string;
@@ -9,7 +10,7 @@ interface Props {
   required?: boolean;
 }
 
-export default function InputField({ label, type = 'text', register, name, required }: Props) {
+function InputField({ label, type = "text", register, name, required }: Props) {
   return (
     <label className="block space-y-1">
       <span className="text-sm font-medium">{label}</span>
@@ -22,3 +23,5 @@ export default function InputField({ label, type = 'text', register, name, requi
     </label>
   );
 }
+
+export default memo(InputField);

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -1,8 +1,8 @@
-'use client';
-import { gsap } from 'gsap';
-import { useEffect, useRef } from 'react';
-import SvgIcon from '../icons/SvgIcon';
-import { sectionEntry } from '@/lib/animations';
+"use client";
+import { motion } from "framer-motion";
+import SvgIcon from "../icons/SvgIcon";
+import { modalVariants } from "@/lib/animations";
+import { memo } from "react";
 
 interface Props {
   open: boolean;
@@ -11,28 +11,42 @@ interface Props {
   children: React.ReactNode;
 }
 
-export default function Modal({ open, onClose, title, children }: Props) {
-  const ref = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (open && ref.current) {
-      gsap.fromTo(ref.current, sectionEntry.from, sectionEntry.to);
-    }
-  }, [open]);
-
+function Modal({ open, onClose, title, children }: Props) {
   if (!open) return null;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40" role="dialog" aria-modal="true" aria-labelledby="modalTitle">
-      <div ref={ref} className="bg-background p-6 rounded-[20px] shadow-neu max-w-md w-full" style={{ willChange: 'transform' }}>
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="modalTitle"
+    >
+      <motion.div
+        variants={modalVariants}
+        initial="initial"
+        animate="animate"
+        exit="exit"
+        className="bg-background p-6 rounded-[20px] shadow-neu max-w-md w-full"
+      >
         <div className="flex justify-between items-center mb-4">
-          <h2 id="modalTitle" className="text-lg font-semibold">{title}</h2>
-          <button aria-label="Close" onClick={onClose} className="focus:outline-none">
+          <h2 id="modalTitle" className="text-lg font-semibold">
+            {title}
+          </h2>
+          <button
+            aria-label="Close"
+            onClick={() => {
+              console.log("[Modal] close clicked");
+              onClose();
+            }}
+            className="focus:outline-none"
+          >
             <SvgIcon name="close" width={16} height={16} />
           </button>
         </div>
         {children}
-      </div>
+      </motion.div>
     </div>
   );
 }
+
+export default memo(Modal);

--- a/src/lib/animations.ts
+++ b/src/lib/animations.ts
@@ -1,12 +1,13 @@
 export const buttonPress = {
-  whileTap: { scale: 0.95, transition: { type: 'spring', stiffness: 300 } }
+  whileTap: { scale: 0.95, transition: { type: "spring", stiffness: 300 } },
 };
 
 export const cardHover = {
-  whileHover: { y: -4, transition: { duration: 0.2 } }
+  whileHover: { y: -4, transition: { duration: 0.2 } },
 };
 
-export const sectionEntry = {
-  from: { opacity: 0, scale: 0.9 },
-  to: { opacity: 1, scale: 1, duration: 0.4, ease: 'power2.out' }
+export const modalVariants = {
+  initial: { opacity: 0, scale: 0.9 },
+  animate: { opacity: 1, scale: 1, transition: { duration: 0.2 } },
+  exit: { opacity: 0, scale: 0.9, transition: { duration: 0.2 } },
 };

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,0 +1,30 @@
+// API stubs for backend integration
+// Replace implementations with real fetch calls
+
+export async function fetchBoxes(userId: string) {
+  console.log("[API] fetchBoxes", { userId });
+  return [] as { boxId: string; name: string; itemsCount?: number }[];
+}
+
+export async function createBox(userId: string, name: string) {
+  console.log("[API] createBox", { userId, name });
+  return { boxId: "temp" };
+}
+
+export async function fetchItems(boxId: string) {
+  console.log("[API] fetchItems", { boxId });
+  return [] as { id: string; name: string }[];
+}
+
+export async function createItem(
+  boxId: string,
+  data: { name: string; category: string; barcode?: string },
+) {
+  console.log("[API] createItem", { boxId, data });
+  return { itemId: "temp" };
+}
+
+export async function fetchReminders(userId: string) {
+  console.log("[API] fetchReminders", { userId });
+  return [] as { type: "expiry" | "reorg"; message: string; color: string }[];
+}


### PR DESCRIPTION
## Summary
- add API stub methods for backend integration
- refactor AddBox and AddItem with hooks and logs
- refactor BoxList and ItemGrid to load data from API
- memoize components and add helpful comments
- replace GSAP modal animation with framer-motion

## Testing
- `npx prettier -w .`
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685e96141ab0832c8cfd7524e9a2aa4c