### PR TITLE
Add landing page and dashboard routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,4 +121,4 @@ npm install
 npm run dev
 ```
 
-The app uses the Next.js App Router with basic pages for Home, Box Detail, and Reminders.
+The app uses the Next.js App Router with pages for the landing screen, dashboard, box detail, and reminders.

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,0 +1,34 @@
+'use client';
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import BoxList from '@/components/BoxList';
+import Insights from '@/components/Insights';
+import AddBox from '@/components/AddBox';
+import Head from 'next/head';
+
+export default function Dashboard() {
+  const router = useRouter();
+  useEffect(() => {
+    const loggedIn = typeof window !== 'undefined' && localStorage.getItem('loggedIn') === 'true';
+    if (!loggedIn) {
+      router.replace('/');
+    }
+    console.log('[Dashboard] page loaded');
+  }, [router]);
+
+  return (
+    <>
+      <Head>
+        <title>BoxMind 대시보드</title>
+      </Head>
+      <main className="p-4 space-y-8">
+        <header className="flex items-center justify-between">
+          <h1 className="text-2xl font-bold">내 정리 공간</h1>
+          <AddBox />
+        </header>
+        <BoxList />
+        <Insights />
+      </main>
+    </>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,26 +1,54 @@
-import { useEffect } from "react";
-import BoxList from "@/components/BoxList";
-import Insights from "@/components/Insights";
-import AddBox from "@/components/AddBox";
-import Head from "next/head";
+'use client';
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import Head from 'next/head';
+import { Button } from '@/components/ui/Button';
+import { Card } from '@/components/ui/Card';
 
-export default function Home() {
+export default function Landing() {
+  const router = useRouter();
   useEffect(() => {
-    console.log("[Home] page loaded");
-  }, []);
+    const loggedIn = typeof window !== 'undefined' && localStorage.getItem('loggedIn') === 'true';
+    if (loggedIn) {
+      router.replace('/dashboard');
+    }
+  }, [router]);
+
+  const start = () => {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('loggedIn', 'true');
+    }
+    router.push('/dashboard');
+  };
 
   return (
     <>
       <Head>
-        <title>BoxMind 홈</title>
+        <title>BoxMind</title>
       </Head>
-      <main className="p-4 space-y-8">
-        <header className="flex items-center justify-between">
-          <h1 className="text-2xl font-bold">내 정리 공간</h1>
-          <AddBox />
-        </header>
-        <BoxList />
-        <Insights />
+      <main className="p-8 space-y-16 text-center">
+        <section className="space-y-6">
+          <h1 className="text-3xl font-bold">BoxMind – Your Digital Declutter Assistant</h1>
+          <p className="text-lg">박스 기반 정리, 알림, AI 분류로 깔끔한 생활을 누리세요.</p>
+          <div className="flex justify-center">
+            <Card className="w-60 h-40 flex items-center justify-center">스크린샷</Card>
+          </div>
+          <Button onClick={start} className="mx-auto">Get Started</Button>
+        </section>
+        <section className="grid md:grid-cols-3 gap-6">
+          <Card className="p-4 space-y-2">
+            <h3 className="font-semibold">Box-Based Organization</h3>
+            <p className="text-sm">공간별로 물건을 손쉽게 관리합니다.</p>
+          </Card>
+          <Card className="p-4 space-y-2">
+            <h3 className="font-semibold">Smart Reminders</h3>
+            <p className="text-sm">만료일과 정리 시점을 알려드려요.</p>
+          </Card>
+          <Card className="p-4 space-y-2">
+            <h3 className="font-semibold">AI Classification</h3>
+            <p className="text-sm">사진만 찍으면 자동으로 분류됩니다.</p>
+          </Card>
+        </section>
       </main>
     </>
   );


### PR DESCRIPTION
## Summary
- create new dashboard page for logged-in users
- implement landing page with hero, features and login button
- redirect based on `loggedIn` localStorage flag
- update README to mention landing and dashboard pages

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865fff83744832c922d31fc7ccb3805