### PR TITLE
Add auth pages and landing page GSAP animation

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "react-dom": "18.3.1",
     "react-hook-form": "7.45.0",
     "zod": "3.22.4",
-    "framer-motion": "11.0.17"
+    "framer-motion": "11.0.17",
+    "gsap": "3.12.5"
   },
   "devDependencies": {
     "autoprefixer": "10.4.17",

--- a/src/app/error/page.tsx
+++ b/src/app/error/page.tsx
@@ -1,0 +1,23 @@
+'use client';
+import { useRouter, useSearchParams } from 'next/navigation';
+import Head from 'next/head';
+import { Button } from '@/components/ui/Button';
+
+export default function ErrorPage() {
+  const router = useRouter();
+  const params = useSearchParams();
+  const message = params.get('message') || '알 수 없는 오류가 발생했습니다.';
+
+  return (
+    <>
+      <Head>
+        <title>Error - BoxMind</title>
+      </Head>
+      <main className="p-8 space-y-4 text-center" aria-label="오류 페이지">
+        <h1 className="text-2xl font-bold">오류 발생</h1>
+        <p>{decodeURIComponent(message)}</p>
+        <Button onClick={() => router.back()} className="mx-auto">이전 페이지</Button>
+      </main>
+    </>
+  );
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,44 @@
+'use client';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import InputField from '@/components/ui/InputField';
+import { Button } from '@/components/ui/Button';
+import { useRouter } from 'next/navigation';
+import { login } from '@/lib/api';
+import Head from 'next/head';
+
+const schema = z.object({ email: z.string().email() });
+type FormData = z.infer<typeof schema>;
+
+export default function LoginPage() {
+  const router = useRouter();
+  const { register, handleSubmit, formState: { errors } } = useForm<FormData>({ resolver: zodResolver(schema) });
+
+  const onSubmit = async (data: FormData) => {
+    console.log('[Login] submit', data);
+    await login(data.email);
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('loggedIn', 'true');
+    }
+    router.push('/dashboard');
+  };
+
+  return (
+    <>
+      <Head>
+        <title>Login - BoxMind</title>
+      </Head>
+      <main className="p-8 space-y-4" aria-label="로그인">
+        <h1 className="text-2xl font-bold text-center">로그인</h1>
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4 max-w-sm mx-auto">
+          <InputField label="이메일" name="email" type="email" register={register} required />
+          {errors.email && (
+            <span className="text-red-500 text-sm">유효한 이메일을 입력하세요</span>
+          )}
+          <Button type="submit" className="w-full">로그인</Button>
+        </form>
+      </main>
+    </>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,18 +1,39 @@
 'use client';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import Head from 'next/head';
 import { Button } from '@/components/ui/Button';
 import { Card } from '@/components/ui/Card';
+import { gsap } from 'gsap';
+import { ScrollTrigger } from 'gsap/ScrollTrigger';
+
+gsap.registerPlugin(ScrollTrigger);
 
 export default function Landing() {
   const router = useRouter();
+  const heroRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
     const loggedIn = typeof window !== 'undefined' && localStorage.getItem('loggedIn') === 'true';
     if (loggedIn) {
       router.replace('/dashboard');
     }
   }, [router]);
+
+  useEffect(() => {
+    const el = heroRef.current;
+    if (!el) return;
+    gsap.fromTo(
+      el.querySelectorAll('.reveal'),
+      { opacity: 0, y: 30 },
+      {
+        opacity: 1,
+        y: 0,
+        duration: 0.6,
+        stagger: 0.2,
+        scrollTrigger: { trigger: el, start: 'top center' },
+      },
+    );
+  }, []);
 
   const start = () => {
     if (typeof window !== 'undefined') {
@@ -27,11 +48,11 @@ export default function Landing() {
         <title>BoxMind</title>
       </Head>
       <main className="p-8 space-y-16 text-center">
-        <section className="space-y-6">
-          <h1 className="text-3xl font-bold">BoxMind – Your Digital Declutter Assistant</h1>
-          <p className="text-lg">박스 기반 정리, 알림, AI 분류로 깔끔한 생활을 누리세요.</p>
+        <section className="space-y-6" ref={heroRef}>
+          <h1 className="text-3xl font-bold reveal">BoxMind – Your Digital Declutter Assistant</h1>
+          <p className="text-lg reveal">박스 기반 정리, 알림, AI 분류로 깔끔한 생활을 누리세요.</p>
           <div className="flex justify-center">
-            <Card className="w-60 h-40 flex items-center justify-center">스크린샷</Card>
+            <Card className="w-60 h-40 flex items-center justify-center reveal">스크린샷</Card>
           </div>
           <Button onClick={start} className="mx-auto">Get Started</Button>
         </section>

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,0 +1,17 @@
+'use client';
+import Head from 'next/head';
+import { Card } from '@/components/ui/Card';
+
+export default function SettingsPage() {
+  return (
+    <>
+      <Head>
+        <title>Settings - BoxMind</title>
+      </Head>
+      <main className="p-8 space-y-4" aria-label="설정">
+        <h1 className="text-2xl font-bold">설정</h1>
+        <Card className="p-4">설정 화면 준비 중</Card>
+      </main>
+    </>
+  );
+}

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -1,0 +1,41 @@
+'use client';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import InputField from '@/components/ui/InputField';
+import { Button } from '@/components/ui/Button';
+import { useRouter } from 'next/navigation';
+import { signUp } from '@/lib/api';
+import Head from 'next/head';
+
+const schema = z.object({ email: z.string().email() });
+type FormData = z.infer<typeof schema>;
+
+export default function SignUpPage() {
+  const router = useRouter();
+  const { register, handleSubmit, formState: { errors } } = useForm<FormData>({ resolver: zodResolver(schema) });
+
+  const onSubmit = async (data: FormData) => {
+    console.log('[SignUp] submit', data);
+    await signUp(data.email);
+    router.push('/login');
+  };
+
+  return (
+    <>
+      <Head>
+        <title>Sign Up - BoxMind</title>
+      </Head>
+      <main className="p-8 space-y-4" aria-label="회원가입">
+        <h1 className="text-2xl font-bold text-center">회원가입</h1>
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4 max-w-sm mx-auto">
+          <InputField label="이메일" name="email" type="email" register={register} required />
+          {errors.email && (
+            <span className="text-red-500 text-sm">유효한 이메일을 입력하세요</span>
+          )}
+          <Button type="submit" className="w-full">가입하기</Button>
+        </form>
+      </main>
+    </>
+  );
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -28,3 +28,13 @@ export async function fetchReminders(userId: string) {
   console.log("[API] fetchReminders", { userId });
   return [] as { type: "expiry" | "reorg"; message: string; color: string }[];
 }
+
+export async function signUp(email: string) {
+  console.log("[API] signUp", { email });
+  return { userId: "temp" };
+}
+
+export async function login(email: string) {
+  console.log("[API] login", { email });
+  return { token: "temp" };
+}


### PR DESCRIPTION
## Summary
- add GSAP dependency
- animate the landing hero with ScrollTrigger
- add SignUp, Login, Error and Settings pages
- extend API stubs with login/signUp helpers

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686616e881c8832ca5577031174f43c0